### PR TITLE
Fix broken link

### DIFF
--- a/stories/loginForm.tsx
+++ b/stories/loginForm.tsx
@@ -133,7 +133,7 @@ const LoginForm: React.FC<Props> = (props) => {
 					)} */}
 					<div className='flex justify-end text-sm'>
 						<Link
-							href={'/auth/forgotPassword'}
+							href={'/auth/forgetPassword'}
 							className='font-medium text-blue-500 underline'
 						>
 							Forgot Password?


### PR DESCRIPTION
## Description

Fix the incorrect link to the "forget password" page.

## Testing Instructions

Ensure that the "forgot password" page loads and works as expected.
