### PR TITLE
Update daily

### DIFF
--- a/app/mainComponent.tsx
+++ b/app/mainComponent.tsx
@@ -14,6 +14,7 @@ import Rightbar from '@/components/shared/rightbar';
 import LogSummary from '@/components/shared/logSummary';
 import MiniCalendarView from '@/components/shared/miniCalendar';
 import LogSummaryList from '@/components/shared/logSummaryList';
+import { ReflectionsType } from '@/components/home/newLogPopup';
 
 export default function MainComponent({
 	children,
@@ -36,12 +37,23 @@ export default function MainComponent({
 		null
 	);
 	const [rightBarHistory, setRightBarHistory] = useState<JSX.Element[]>([]);
-	const handleLogClick = (log: { date: Date; mood: string; icon: string }) => {
+	const handleLogClick = (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => {
 		setRightBarHistory((prevHistory) =>
 			rightBarContent ? [...prevHistory, rightBarContent] : prevHistory
 		);
-		setRightBarContent(<LogSummary log={log} handleGoBack={handleGoBack} />);
+		setRightBarContent(
+			<LogSummary
+				log={{ ...log, reflections: log.reflections || [] }}
+				handleGoBack={handleGoBack}
+			/>
+		);
 		setRightBarOpen(true);
+		console.log('Log clicked:', log);
 	};
 
 	const handleGoBack = () => {
@@ -66,8 +78,8 @@ export default function MainComponent({
 	}, [isPopupOpen]);
 
 	const handleAddLogClick = useCallback(() => {
-		setValue(selectedDate); // Use the selected date here
-		setPopupOpen(true); // Directly set the popup to open
+		setValue(selectedDate);
+		setPopupOpen(true);
 	}, [selectedDate]);
 
 	const handleDateChange = (newValue: Value) => {
@@ -115,7 +127,7 @@ export default function MainComponent({
 					value={value}
 					setValue={setValue}
 					isPopupOpen={isPopupOpen}
-				setPopupOpen={setPopupOpen}
+					setPopupOpen={setPopupOpen}
 					handleDateChange={handleDateChange}
 					handleLogClick={handleLogClick}
 				/>

--- a/app/mainComponent.tsx
+++ b/app/mainComponent.tsx
@@ -56,20 +56,21 @@ export default function MainComponent({
 		console.log('Log clicked:', log);
 	};
 
-	const handleGoBack = () => {
-		console.log('Go back clicked');
-		setRightBarHistory((prevHistory) => {
-			const newHistory = prevHistory.filter((item) => item !== null);
-			const lastContent = newHistory.pop();
-			if (lastContent !== undefined) {
-				setRightBarContent(lastContent);
-			}
-			return newHistory;
-		});
-	};
-
 	const handleRightBarToggle = (open: boolean) => {
 		setRightBarOpen(open);
+	};
+
+	const handleGoBack = () => {
+		console.log('Go back clicked');
+		setRightBarContent(
+			<LogSummaryList
+				handleLogClick={handleLogClick}
+				selectedDate={selectedDate}
+				value={value}
+				setValue={setValue}
+				handleDateChange={handleDateChange}
+			/>
+		);
 	};
 
 	const handlePopupToggle = useCallback(() => {
@@ -172,6 +173,11 @@ export default function MainComponent({
 					<Rightbar
 						isRightBarOpen={isRightBarOpen}
 						onToggle={handleRightBarToggle}
+						handleLogClick={handleLogClick}
+						selectedDate={selectedDate}
+						value={value}
+						setValue={setValue}
+						handleDateChange={handleDateChange}
 					>
 						{rightBarContent}
 					</Rightbar>

--- a/components/home/calendar.tsx
+++ b/components/home/calendar.tsx
@@ -35,7 +35,12 @@ type Props = {
 
 	setPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
 	handleDateChange: (newValue: Value) => void;
-	handleLogClick: (log: { date: Date; mood: string; icon: string }) => void;
+	handleLogClick: (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => void;
 };
 type ValuePiece = Date | null;
 
@@ -44,6 +49,7 @@ export type Value = ValuePiece | [ValuePiece, ValuePiece];
 export type MoodEntry = {
 	date: string;
 	mood: string;
+	reflections: ReflectionsType[];
 };
 
 const CalendarView = ({
@@ -60,7 +66,9 @@ const CalendarView = ({
 	handleLogClick,
 }: Props) => {
 	const { user, updateData, isUpdated } = useAuth();
-	const [moods, setMoods] = useState<{ [key: string]: string }>({});
+	const [moods, setMoods] = useState<{
+		[key: string]: { mood: string; reflections: ReflectionsType[] };
+	}>({});
 	const [isYearDropdownOpen, setYearDropdownOpen] = useState(false);
 	const [displayedYear, setDisplayedYear] = useState(new Date().getFullYear());
 
@@ -68,14 +76,19 @@ const CalendarView = ({
 		if (user) {
 			getUser(user.uid).then((userData) => {
 				if (userData && userData.moods) {
-					let moodMap: { [key: string]: string } = {};
+					let moodMap: {
+						[key: string]: { mood: string; reflections: ReflectionsType[] };
+					} = {}; // Update this line
 
 					userData.moods.forEach((moodEntry: MoodEntry) => {
 						const dateParts = moodEntry.date
 							.split('-')
 							.map((part) => parseInt(part, 10));
 						const date = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
-						moodMap[formatValueTypeToYYYYMMDD(date)] = moodEntry.mood;
+						moodMap[formatValueTypeToYYYYMMDD(date)] = {
+							mood: moodEntry.mood,
+							reflections: moodEntry.reflections,
+						}; // Update this line
 					});
 					setMoods(moodMap);
 				}
@@ -104,7 +117,7 @@ const CalendarView = ({
 			document.removeEventListener('mousedown', handleClickOutside);
 		};
 	}, [isYearDropdownOpen]);
-console.log(isUpdated);
+	console.log(isUpdated);
 	useEffect(() => {
 		setDisplayedYear((selectedDate as Date).getFullYear());
 	}, [selectedDate]);
@@ -116,10 +129,15 @@ console.log(isUpdated);
 	) => {
 		if (user) {
 			await addUserMood(user.uid, mood, date, reflections);
-			// setMoods((prev) => ({ ...prev, [date]: mood }));
 			updateData();
-		
-
+			// Call handleLogClick after the new log is saved
+			console.log('Log saved:', date, mood, reflections);
+			handleLogClick({
+				date: new Date(date),
+				mood: mood,
+				icon: `/moods/${mood.toLowerCase()}.svg`,
+				reflections: reflections,
+			});
 		}
 	};
 
@@ -238,10 +256,11 @@ console.log(isUpdated);
 								const todayKey = formatValueTypeToYYYYMMDD(today);
 								handleLogClick({
 									date: today,
-									mood: moods[todayKey],
+									mood: moods[todayKey].mood,
 									icon: moods[todayKey]
-										? `/moods/${moods[todayKey].toLowerCase()}.svg`
+										? `/moods/${moods[todayKey].mood.toLowerCase()}.svg`
 										: '/moods/greyWithFace.svg',
+									reflections: moods[todayKey].reflections,
 								});
 							}}
 						>
@@ -278,8 +297,9 @@ console.log(isUpdated);
 								onClick={() =>
 									handleLogClick({
 										date: date,
-										mood: moods[dateKey],
+										mood: moods[dateKey].mood,
 										icon: '/moods/greyNoFace.svg',
+										reflections: moods[dateKey].reflections,
 									})
 								}
 							/>
@@ -287,15 +307,16 @@ console.log(isUpdated);
 					}
 					return moods[dateKey] ? (
 						<Image
-							src={`/moods/${moods[dateKey].toLowerCase()}.svg`}
+							src={`/moods/${moods[dateKey].mood.toLowerCase()}.svg`}
 							alt='Mood'
 							height={150}
 							width={150}
 							onClick={() =>
 								handleLogClick({
 									date: date,
-									mood: moods[dateKey],
-									icon: `/moods/${moods[dateKey].toLowerCase()}.svg`,
+									mood: moods[dateKey].mood,
+									icon: `/moods/${moods[dateKey].mood.toLowerCase()}.svg`,
+									reflections: moods[dateKey].reflections,
 								})
 							}
 						/>
@@ -308,8 +329,9 @@ console.log(isUpdated);
 							onClick={() =>
 								handleLogClick({
 									date: date,
-									mood: moods[dateKey],
+									mood: 'No Log Yet',
 									icon: '/moods/greyWithFace.svg',
+									reflections: [],
 								})
 							}
 						/>
@@ -329,6 +351,7 @@ console.log(isUpdated);
 				displayDate={formatDateToDayMonthDateYear(selectedDate as Date)}
 				saveMood={saveMood}
 				setPopupOpen={setPopupOpen}
+				handleLogClick={handleLogClick}
 			/>
 		</div>
 	);

--- a/components/home/calendar.tsx
+++ b/components/home/calendar.tsx
@@ -78,7 +78,7 @@ const CalendarView = ({
 				if (userData && userData.moods) {
 					let moodMap: {
 						[key: string]: { mood: string; reflections: ReflectionsType[] };
-					} = {}; // Update this line
+					} = {};
 
 					userData.moods.forEach((moodEntry: MoodEntry) => {
 						const dateParts = moodEntry.date

--- a/components/home/moodPrompts.tsx
+++ b/components/home/moodPrompts.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/stories/Button';
 import { CaretLeft, Plus, Minus } from '@phosphor-icons/react';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { ReflectionsType } from './newLogPopup';
 
 type Props = {
@@ -14,73 +14,78 @@ const MoodPrompts = ({
 	initialReflections,
 	handleSaveMood,
 }: Props) => {
-	const defaultQuestions = {
-		Rainbow: [
-			{
-				question: 'What made you happy today?',
-				answer: '',
-			},
-			{
-				question: 'What are you looking forward to?',
-				answer: '',
-			},
-		],
-		Sunny: [
-			{
-				question: 'What is troubling you?',
-				answer: '',
-			},
-			{
-				question: 'How can you improve your mood?',
-				answer: '',
-			},
-		],
-		Cloudy: [
-			{
-				question: 'What is making you excited?',
-				answer: '',
-			},
-			{
-				question: 'What are your plans for the day?',
-				answer: '',
-			},
-		],
-		Rainy: [
-			{
-				question: 'What is making you excited?',
-				answer: '',
-			},
-			{
-				question: 'What are your plans for the day?',
-				answer: '',
-			},
-		],
-		Stormy: [
-			{
-				question: 'What is making you excited?',
-				answer: '',
-			},
-			{
-				question: 'What are your plans for the day?',
-				answer: '',
-			},
-		],
-	};
+	const defaultQuestions = useMemo(
+		() => ({
+			Rainbow: [
+				{
+					question: 'What made you happy today?',
+					answer: '',
+				},
+				{
+					question: 'What are you looking forward to?',
+					answer: '',
+				},
+			],
+			Sunny: [
+				{
+					question: 'What is troubling you?',
+					answer: '',
+				},
+				{
+					question: 'How can you improve your mood?',
+					answer: '',
+				},
+			],
+			Cloudy: [
+				{
+					question: 'What is making you excited?',
+					answer: '',
+				},
+				{
+					question: 'What are your plans for the day?',
+					answer: '',
+				},
+			],
+			Rainy: [
+				{
+					question: 'What is making you excited?',
+					answer: '',
+				},
+				{
+					question: 'What are your plans for the day?',
+					answer: '',
+				},
+			],
+			Stormy: [
+				{
+					question: 'What is making you excited?',
+					answer: '',
+				},
+				{
+					question: 'What are your plans for the day?',
+					answer: '',
+				},
+			],
+		}),
+		[]
+	);
 
 	const [reflections, setReflections] = useState(
-		initialReflections.length
+		initialReflections && initialReflections.length
 			? initialReflections
 			: defaultQuestions[selectedMood as keyof typeof defaultQuestions]
 	);
 	const [openReflections, setOpenReflections] = useState<number[]>([]);
 
 	useEffect(() => {
-		if (initialReflections.length === 0) {
+		if (initialReflections && initialReflections.length > 0) {
+			setReflections(initialReflections);
+		} else {
 			setReflections(
 				defaultQuestions[selectedMood as keyof typeof defaultQuestions]
 			);
 		}
-	}, [selectedMood, initialReflections]);
+	}, [selectedMood, initialReflections, defaultQuestions]);
 
 	const toggleReflection = (index: number) => {
 		setOpenReflections((prevState) =>

--- a/components/home/newLogPopup.tsx
+++ b/components/home/newLogPopup.tsx
@@ -23,6 +23,12 @@ type Props = {
 		reflections: ReflectionsType[]
 	) => Promise<void>;
 	setPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
+	handleLogClick: (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => void;
 };
 
 type Mood = {
@@ -36,6 +42,7 @@ const NewLogPopup = ({
 	displayDate,
 	saveMood,
 	setPopupOpen,
+	handleLogClick,
 }: Props) => {
 	const [selectedMood, setSelectedMood] = useState<string>(''); // State to hold the selected mood
 	const [currentStep, setCurrentStep] = useState<number>(1); // State to hold the selected mood
@@ -100,6 +107,7 @@ const NewLogPopup = ({
 	const handleSaveMood = async (reflections: ReflectionsType[]) => {
 		if (!user) return;
 		await saveMood(selectedDate, selectedMood, reflections);
+		console.log('Saved reflections:', reflections);
 		setPopupOpen(false);
 		setCurrentStep(1);
 		console.log('handleSaveMood: Closing popup');

--- a/components/shared/filterDropdown.tsx
+++ b/components/shared/filterDropdown.tsx
@@ -1,7 +1,7 @@
 // components/FilterDropdown.js
 import React, { useState } from 'react';
 import { IoMdFunnel } from 'react-icons/io';
-import { MoodNames } from './rightbar';
+import { MoodNames } from './logSummaryList';
 
 type props = {
 	handleCheckboxChange: (filter: string) => void;

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -61,12 +61,16 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 			<div className='flex max-h-24 flex-col gap-5 pb-4'>
 				<div className='flex w-full flex-row items-center justify-between  px-1 text-base font-semibold'>
 					<div className='flex flex-row gap-2 text-primary'>
-						<button onClick={handleGoBack}>
+						<button
+							onClick={handleGoBack}
+							className='flex flex-row items-center justify-center gap-2'
+						>
 							<CaretLeft size={16} weight='bold' />
+							<span className='flex min-h-12 w-fit items-center justify-center py-1 text-base'>
+								{/* {formatDateToMonthDayYear(log.date)} */}
+								Back to Summary
+							</span>
 						</button>
-						<span className='flex min-h-12 w-fit items-center justify-center py-1 text-base'>
-							{formatDateToMonthDayYear(log.date)}
-						</span>
 					</div>
 				</div>
 				{/* Divider */}

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -11,7 +11,12 @@ import { useAuth } from '@/app/context/UserProvider';
 import { getUser } from '../utils/serverFunctions';
 
 interface LogSummaryProps {
-	log: { date: Date; mood: string; icon: string };
+	log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections: ReflectionsType[];
+	};
 	handleGoBack: () => void;
 }
 
@@ -42,28 +47,6 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 		ReflectionsType[]
 	>([]);
 	console.log(isUpdated);
-	useEffect(() => {
-		if (user && log.date) {
-			const formattedDate = formatValueTypeToYYYYMMDD(log.date);
-			getUser(user.uid).then((userData) => {
-				if (!userData || !userData.moods || userData.moods.length === 0) {
-					console.log('No mood data found for the user');
-					return;
-				}
-				console.log('All mood entries:', userData.moods);
-
-				const selectedMoodEntry = userData.moods.find(
-					(entry: any) => entry.date === formattedDate
-				);
-				console.log(formattedDate);
-				if (selectedMoodEntry && selectedMoodEntry.reflections) {
-					setInitialReflections(selectedMoodEntry.reflections);
-				} else {
-					setInitialReflections([]);
-				}
-			});
-		}
-	}, [user, log.date, isUpdated]);
 
 	const toggleReflection = (index: number) => {
 		setOpenReflections((prevState) =>
@@ -130,17 +113,15 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 					</div>
 				</div>
 				{/* Reflections */}
-				{initialReflections.length > 0 ? (
+				{log.reflections.length > 0 ? (
 					<div className='flex flex-col gap-3'>
 						<div className='flex flex-row items-center justify-start  gap-2 text-sm'>
 							<span className='font-semibold'>Reflections</span>
-							<span className='text-[#706F6F]'>
-								({initialReflections.length})
-							</span>
+							<span className='text-[#706F6F]'>({log.reflections.length})</span>
 						</div>
 						{/* render a div for every item in reflections */}
 
-						{initialReflections.map((reflection, index) => (
+						{log.reflections.map((reflection, index) => (
 							<div
 								key={index}
 								className={`grid gap-x-5 px-4 py-2 ${openReflections.includes(index) ? 'question-opened grid-cols-[1fr_min-content] grid-rows-2 items-center' : 'question-closed grid-cols-[1fr_min-content] grid-rows-1 rounded-lg border border-[#DEE9F5] bg-[#FAFCFF]'}`}

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Calendar from 'react-calendar';
-
+import { ReflectionsType } from '@/components/home/newLogPopup';
 import { useAuth } from '@/app/context/UserProvider';
 import { getUser, addUserMood } from '../utils/serverFunctions';
 import '/app/styles/miniCalendar.css';
@@ -27,7 +27,12 @@ type Props = {
 	value: Value | null;
 	setValue: React.Dispatch<React.SetStateAction<Value | null>>;
 	handleDateChange: (newValue: Value) => void;
-	handleLogClick: (log: { date: Date; mood: string; icon: string }) => void;
+	handleLogClick: (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => void;
 };
 
 type ValuePiece = Date | null;


### PR DESCRIPTION
## Description

1) When you click on an entry in the summary view, now it opens that log's daily view.
2) When you complete a new log, now that log's daily view automatically renders in the right sidebar
3) When you click on an entry in the summary view, that log's date is auto-selected in both calendars.

## Related Issue

[#33: Feature: As a user, I want a "Back to Summary" button in the daily view so that I can see the log summary list. ](https://github.com/cherryontech/jupiter-jumpers/issues/33)

[ #45 Bug: Summary page to Daily view page](https://github.com/cherryontech/jupiter-jumpers/issues/45)

## Related Story Card

[SCRUM 55](https://cherryontech-jupiter-jumpers.atlassian.net/browse/SCRUM-55)

## Type of Changes

Functionality updates

## Acceptance Criteria

- [X] Given I am viewing the summary page
- [X] When I click on a particular mood log’s summary tile
- [X] Then I can see the “daily view” for that log in the same right sidebar

## Update Screenshots

### Before

### After

## Testing Instructions

1. Try adding a new log, and ensure that its daily view renders (and that the contents are all correct).
2. Try clicking a log in the summary view, and ensure that the log's date is selected in the calendars.
3. Try clicking a log in the summary view, and sure that the log's daily view opens in the right sidebar.

## Learnings (Optional)

