### PR TITLE
Mini calendar issues

### DIFF
--- a/app/mainComponent.tsx
+++ b/app/mainComponent.tsx
@@ -14,6 +14,7 @@ import Rightbar from '@/components/shared/rightbar';
 import LogSummary from '@/components/shared/logSummary';
 import MiniCalendarView from '@/components/shared/miniCalendar';
 import LogSummaryList from '@/components/shared/logSummaryList';
+import { ReflectionsType } from '@/components/home/newLogPopup';
 
 export default function MainComponent({
 	children,
@@ -36,12 +37,23 @@ export default function MainComponent({
 		null
 	);
 	const [rightBarHistory, setRightBarHistory] = useState<JSX.Element[]>([]);
-	const handleLogClick = (log: { date: Date; mood: string; icon: string }) => {
+	const handleLogClick = (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => {
 		setRightBarHistory((prevHistory) =>
 			rightBarContent ? [...prevHistory, rightBarContent] : prevHistory
 		);
-		setRightBarContent(<LogSummary log={log} handleGoBack={handleGoBack} />);
+		setRightBarContent(
+			<LogSummary
+				log={{ ...log, reflections: log.reflections || [] }}
+				handleGoBack={handleGoBack}
+			/>
+		);
 		setRightBarOpen(true);
+		console.log('Log clicked:', log);
 	};
 
 	const handleGoBack = () => {
@@ -66,8 +78,8 @@ export default function MainComponent({
 	}, [isPopupOpen]);
 
 	const handleAddLogClick = useCallback(() => {
-		setValue(selectedDate); // Use the selected date here
-		setPopupOpen(true); // Directly set the popup to open
+		setValue(selectedDate);
+		setPopupOpen(true);
 	}, [selectedDate]);
 
 	const handleDateChange = (newValue: Value) => {
@@ -115,7 +127,7 @@ export default function MainComponent({
 					value={value}
 					setValue={setValue}
 					isPopupOpen={isPopupOpen}
-				setPopupOpen={setPopupOpen}
+					setPopupOpen={setPopupOpen}
 					handleDateChange={handleDateChange}
 					handleLogClick={handleLogClick}
 				/>

--- a/app/mainComponent.tsx
+++ b/app/mainComponent.tsx
@@ -56,20 +56,21 @@ export default function MainComponent({
 		console.log('Log clicked:', log);
 	};
 
-	const handleGoBack = () => {
-		console.log('Go back clicked');
-		setRightBarHistory((prevHistory) => {
-			const newHistory = prevHistory.filter((item) => item !== null);
-			const lastContent = newHistory.pop();
-			if (lastContent !== undefined) {
-				setRightBarContent(lastContent);
-			}
-			return newHistory;
-		});
-	};
-
 	const handleRightBarToggle = (open: boolean) => {
 		setRightBarOpen(open);
+	};
+
+	const handleGoBack = () => {
+		console.log('Go back clicked');
+		setRightBarContent(
+			<LogSummaryList
+				handleLogClick={handleLogClick}
+				selectedDate={selectedDate}
+				value={value}
+				setValue={setValue}
+				handleDateChange={handleDateChange}
+			/>
+		);
 	};
 
 	const handlePopupToggle = useCallback(() => {
@@ -172,6 +173,11 @@ export default function MainComponent({
 					<Rightbar
 						isRightBarOpen={isRightBarOpen}
 						onToggle={handleRightBarToggle}
+						handleLogClick={handleLogClick}
+						selectedDate={selectedDate}
+						value={value}
+						setValue={setValue}
+						handleDateChange={handleDateChange}
 					>
 						{rightBarContent}
 					</Rightbar>

--- a/app/styles/miniCalendar.css
+++ b/app/styles/miniCalendar.css
@@ -235,23 +235,15 @@
 .mini-calendar .calendar-heading.dropdown-open {
 	background-color: #dee9f5;
 }
-.mini-calendar .calendar-dropdown {
-	position: absolute;
-	top: 120%;
-	left: 0%;
+.mini-calendar .mini-calendar-dropdown {
 	background-color: white;
-	border: 1px solid #dee9f5;
-	padding: 0.75rem;
-	z-index: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	gap: 0.75rem;
-	width: fit-content;
-	border-radius: 0.5rem;
-	box-shadow: 0px 15px 20px 0px rgba(0, 0, 0, 0.03);
+	width: 100%;
 }
-.mini-calendar .calendar-dropdown-year {
+.mini-calendar .mini-calendar-dropdown-year {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -260,10 +252,11 @@
 	font-size: 0.875rem;
 	padding: 0 0.375rem;
 }
-.mini-calendar .calendar-dropdown-months {
+.mini-calendar .mini-calendar-dropdown-months {
 	display: grid;
 	grid-template-columns: repeat(4, 1fr);
 	gap: 0.75rem;
+	width: 100%;
 }
 .mini-calendar .calendar-dropdown-item {
 	display: flex;

--- a/app/styles/miniCalendar.css
+++ b/app/styles/miniCalendar.css
@@ -96,6 +96,11 @@
 	/* bottom: 1rem; */
 }
 .mini-calendar .react-calendar__tile--active abbr {
+	background: #dee9f5;
+	color: #2d81e0;
+}
+
+.mini-calendar .react-calendar__tile--today abbr {
 	background: #2d81e0;
 	color: white;
 }
@@ -157,6 +162,7 @@
 	font-weight: 400;
 	overflow: visible !important;
 	padding: 0.1rem;
+	gap: 0.3rem;
 }
 
 .mini-calendar .react-calendar__tile {
@@ -286,4 +292,8 @@
 	height: 0.5rem;
 	border-radius: 50%;
 	background-color: #2d81e0;
+}
+
+.today {
+	background-color: blue !important;
 }

--- a/components/home/calendar.tsx
+++ b/components/home/calendar.tsx
@@ -35,7 +35,12 @@ type Props = {
 
 	setPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
 	handleDateChange: (newValue: Value) => void;
-	handleLogClick: (log: { date: Date; mood: string; icon: string }) => void;
+	handleLogClick: (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => void;
 };
 type ValuePiece = Date | null;
 
@@ -44,6 +49,7 @@ export type Value = ValuePiece | [ValuePiece, ValuePiece];
 export type MoodEntry = {
 	date: string;
 	mood: string;
+	reflections: ReflectionsType[];
 };
 
 const CalendarView = ({
@@ -60,7 +66,9 @@ const CalendarView = ({
 	handleLogClick,
 }: Props) => {
 	const { user, updateData, isUpdated } = useAuth();
-	const [moods, setMoods] = useState<{ [key: string]: string }>({});
+	const [moods, setMoods] = useState<{
+		[key: string]: { mood: string; reflections: ReflectionsType[] };
+	}>({});
 	const [isYearDropdownOpen, setYearDropdownOpen] = useState(false);
 	const [displayedYear, setDisplayedYear] = useState(new Date().getFullYear());
 
@@ -68,14 +76,19 @@ const CalendarView = ({
 		if (user) {
 			getUser(user.uid).then((userData) => {
 				if (userData && userData.moods) {
-					let moodMap: { [key: string]: string } = {};
+					let moodMap: {
+						[key: string]: { mood: string; reflections: ReflectionsType[] };
+					} = {}; // Update this line
 
 					userData.moods.forEach((moodEntry: MoodEntry) => {
 						const dateParts = moodEntry.date
 							.split('-')
 							.map((part) => parseInt(part, 10));
 						const date = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
-						moodMap[formatValueTypeToYYYYMMDD(date)] = moodEntry.mood;
+						moodMap[formatValueTypeToYYYYMMDD(date)] = {
+							mood: moodEntry.mood,
+							reflections: moodEntry.reflections,
+						}; // Update this line
 					});
 					setMoods(moodMap);
 				}
@@ -104,7 +117,7 @@ const CalendarView = ({
 			document.removeEventListener('mousedown', handleClickOutside);
 		};
 	}, [isYearDropdownOpen]);
-console.log(isUpdated);
+	console.log(isUpdated);
 	useEffect(() => {
 		setDisplayedYear((selectedDate as Date).getFullYear());
 	}, [selectedDate]);
@@ -116,10 +129,15 @@ console.log(isUpdated);
 	) => {
 		if (user) {
 			await addUserMood(user.uid, mood, date, reflections);
-			// setMoods((prev) => ({ ...prev, [date]: mood }));
 			updateData();
-		
-
+			// Call handleLogClick after the new log is saved
+			console.log('Log saved:', date, mood, reflections);
+			handleLogClick({
+				date: new Date(date),
+				mood: mood,
+				icon: `/moods/${mood.toLowerCase()}.svg`,
+				reflections: reflections,
+			});
 		}
 	};
 
@@ -238,10 +256,11 @@ console.log(isUpdated);
 								const todayKey = formatValueTypeToYYYYMMDD(today);
 								handleLogClick({
 									date: today,
-									mood: moods[todayKey],
+									mood: moods[todayKey].mood,
 									icon: moods[todayKey]
-										? `/moods/${moods[todayKey].toLowerCase()}.svg`
+										? `/moods/${moods[todayKey].mood.toLowerCase()}.svg`
 										: '/moods/greyWithFace.svg',
+									reflections: moods[todayKey].reflections,
 								});
 							}}
 						>
@@ -278,8 +297,9 @@ console.log(isUpdated);
 								onClick={() =>
 									handleLogClick({
 										date: date,
-										mood: moods[dateKey],
+										mood: moods[dateKey].mood,
 										icon: '/moods/greyNoFace.svg',
+										reflections: moods[dateKey].reflections,
 									})
 								}
 							/>
@@ -287,15 +307,16 @@ console.log(isUpdated);
 					}
 					return moods[dateKey] ? (
 						<Image
-							src={`/moods/${moods[dateKey].toLowerCase()}.svg`}
+							src={`/moods/${moods[dateKey].mood.toLowerCase()}.svg`}
 							alt='Mood'
 							height={150}
 							width={150}
 							onClick={() =>
 								handleLogClick({
 									date: date,
-									mood: moods[dateKey],
-									icon: `/moods/${moods[dateKey].toLowerCase()}.svg`,
+									mood: moods[dateKey].mood,
+									icon: `/moods/${moods[dateKey].mood.toLowerCase()}.svg`,
+									reflections: moods[dateKey].reflections,
 								})
 							}
 						/>
@@ -308,8 +329,9 @@ console.log(isUpdated);
 							onClick={() =>
 								handleLogClick({
 									date: date,
-									mood: moods[dateKey],
+									mood: 'No Log Yet',
 									icon: '/moods/greyWithFace.svg',
+									reflections: [],
 								})
 							}
 						/>
@@ -329,6 +351,7 @@ console.log(isUpdated);
 				displayDate={formatDateToDayMonthDateYear(selectedDate as Date)}
 				saveMood={saveMood}
 				setPopupOpen={setPopupOpen}
+				handleLogClick={handleLogClick}
 			/>
 		</div>
 	);

--- a/components/home/calendar.tsx
+++ b/components/home/calendar.tsx
@@ -78,7 +78,7 @@ const CalendarView = ({
 				if (userData && userData.moods) {
 					let moodMap: {
 						[key: string]: { mood: string; reflections: ReflectionsType[] };
-					} = {}; // Update this line
+					} = {};
 
 					userData.moods.forEach((moodEntry: MoodEntry) => {
 						const dateParts = moodEntry.date

--- a/components/home/moodPrompts.tsx
+++ b/components/home/moodPrompts.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/stories/Button';
 import { CaretLeft, Plus, Minus } from '@phosphor-icons/react';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { ReflectionsType } from './newLogPopup';
 
 type Props = {
@@ -14,73 +14,78 @@ const MoodPrompts = ({
 	initialReflections,
 	handleSaveMood,
 }: Props) => {
-	const defaultQuestions = {
-		Rainbow: [
-			{
-				question: 'What made you happy today?',
-				answer: '',
-			},
-			{
-				question: 'What are you looking forward to?',
-				answer: '',
-			},
-		],
-		Sunny: [
-			{
-				question: 'What is troubling you?',
-				answer: '',
-			},
-			{
-				question: 'How can you improve your mood?',
-				answer: '',
-			},
-		],
-		Cloudy: [
-			{
-				question: 'What is making you excited?',
-				answer: '',
-			},
-			{
-				question: 'What are your plans for the day?',
-				answer: '',
-			},
-		],
-		Rainy: [
-			{
-				question: 'What is making you excited?',
-				answer: '',
-			},
-			{
-				question: 'What are your plans for the day?',
-				answer: '',
-			},
-		],
-		Stormy: [
-			{
-				question: 'What is making you excited?',
-				answer: '',
-			},
-			{
-				question: 'What are your plans for the day?',
-				answer: '',
-			},
-		],
-	};
+	const defaultQuestions = useMemo(
+		() => ({
+			Rainbow: [
+				{
+					question: 'What made you happy today?',
+					answer: '',
+				},
+				{
+					question: 'What are you looking forward to?',
+					answer: '',
+				},
+			],
+			Sunny: [
+				{
+					question: 'What is troubling you?',
+					answer: '',
+				},
+				{
+					question: 'How can you improve your mood?',
+					answer: '',
+				},
+			],
+			Cloudy: [
+				{
+					question: 'What is making you excited?',
+					answer: '',
+				},
+				{
+					question: 'What are your plans for the day?',
+					answer: '',
+				},
+			],
+			Rainy: [
+				{
+					question: 'What is making you excited?',
+					answer: '',
+				},
+				{
+					question: 'What are your plans for the day?',
+					answer: '',
+				},
+			],
+			Stormy: [
+				{
+					question: 'What is making you excited?',
+					answer: '',
+				},
+				{
+					question: 'What are your plans for the day?',
+					answer: '',
+				},
+			],
+		}),
+		[]
+	);
 
 	const [reflections, setReflections] = useState(
-		initialReflections.length
+		initialReflections && initialReflections.length
 			? initialReflections
 			: defaultQuestions[selectedMood as keyof typeof defaultQuestions]
 	);
 	const [openReflections, setOpenReflections] = useState<number[]>([]);
 
 	useEffect(() => {
-		if (initialReflections.length === 0) {
+		if (initialReflections && initialReflections.length > 0) {
+			setReflections(initialReflections);
+		} else {
 			setReflections(
 				defaultQuestions[selectedMood as keyof typeof defaultQuestions]
 			);
 		}
-	}, [selectedMood, initialReflections]);
+	}, [selectedMood, initialReflections, defaultQuestions]);
 
 	const toggleReflection = (index: number) => {
 		setOpenReflections((prevState) =>

--- a/components/home/newLogPopup.tsx
+++ b/components/home/newLogPopup.tsx
@@ -23,6 +23,12 @@ type Props = {
 		reflections: ReflectionsType[]
 	) => Promise<void>;
 	setPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
+	handleLogClick: (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => void;
 };
 
 type Mood = {
@@ -36,6 +42,7 @@ const NewLogPopup = ({
 	displayDate,
 	saveMood,
 	setPopupOpen,
+	handleLogClick,
 }: Props) => {
 	const [selectedMood, setSelectedMood] = useState<string>(''); // State to hold the selected mood
 	const [currentStep, setCurrentStep] = useState<number>(1); // State to hold the selected mood
@@ -100,6 +107,7 @@ const NewLogPopup = ({
 	const handleSaveMood = async (reflections: ReflectionsType[]) => {
 		if (!user) return;
 		await saveMood(selectedDate, selectedMood, reflections);
+		console.log('Saved reflections:', reflections);
 		setPopupOpen(false);
 		setCurrentStep(1);
 		console.log('handleSaveMood: Closing popup');

--- a/components/shared/filterDropdown.tsx
+++ b/components/shared/filterDropdown.tsx
@@ -1,7 +1,7 @@
 // components/FilterDropdown.js
 import React, { useState } from 'react';
 import { IoMdFunnel } from 'react-icons/io';
-import { MoodNames } from './rightbar';
+import { MoodNames } from './logSummaryList';
 
 type props = {
 	handleCheckboxChange: (filter: string) => void;

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -61,12 +61,16 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 			<div className='flex max-h-24 flex-col gap-5 pb-4'>
 				<div className='flex w-full flex-row items-center justify-between  px-1 text-base font-semibold'>
 					<div className='flex flex-row gap-2 text-primary'>
-						<button onClick={handleGoBack}>
+						<button
+							onClick={handleGoBack}
+							className='flex flex-row items-center justify-center gap-2'
+						>
 							<CaretLeft size={16} weight='bold' />
+							<span className='flex min-h-12 w-fit items-center justify-center py-1 text-base'>
+								{/* {formatDateToMonthDayYear(log.date)} */}
+								Back to Summary
+							</span>
 						</button>
-						<span className='flex min-h-12 w-fit items-center justify-center py-1 text-base'>
-							{formatDateToMonthDayYear(log.date)}
-						</span>
 					</div>
 				</div>
 				{/* Divider */}

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -11,7 +11,12 @@ import { useAuth } from '@/app/context/UserProvider';
 import { getUser } from '../utils/serverFunctions';
 
 interface LogSummaryProps {
-	log: { date: Date; mood: string; icon: string };
+	log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections: ReflectionsType[];
+	};
 	handleGoBack: () => void;
 }
 
@@ -42,28 +47,6 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 		ReflectionsType[]
 	>([]);
 	console.log(isUpdated);
-	useEffect(() => {
-		if (user && log.date) {
-			const formattedDate = formatValueTypeToYYYYMMDD(log.date);
-			getUser(user.uid).then((userData) => {
-				if (!userData || !userData.moods || userData.moods.length === 0) {
-					console.log('No mood data found for the user');
-					return;
-				}
-				console.log('All mood entries:', userData.moods);
-
-				const selectedMoodEntry = userData.moods.find(
-					(entry: any) => entry.date === formattedDate
-				);
-				console.log(formattedDate);
-				if (selectedMoodEntry && selectedMoodEntry.reflections) {
-					setInitialReflections(selectedMoodEntry.reflections);
-				} else {
-					setInitialReflections([]);
-				}
-			});
-		}
-	}, [user, log.date, isUpdated]);
 
 	const toggleReflection = (index: number) => {
 		setOpenReflections((prevState) =>
@@ -130,17 +113,15 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 					</div>
 				</div>
 				{/* Reflections */}
-				{initialReflections.length > 0 ? (
+				{log.reflections.length > 0 ? (
 					<div className='flex flex-col gap-3'>
 						<div className='flex flex-row items-center justify-start  gap-2 text-sm'>
 							<span className='font-semibold'>Reflections</span>
-							<span className='text-[#706F6F]'>
-								({initialReflections.length})
-							</span>
+							<span className='text-[#706F6F]'>({log.reflections.length})</span>
 						</div>
 						{/* render a div for every item in reflections */}
 
-						{initialReflections.map((reflection, index) => (
+						{log.reflections.map((reflection, index) => (
 							<div
 								key={index}
 								className={`grid gap-x-5 px-4 py-2 ${openReflections.includes(index) ? 'question-opened grid-cols-[1fr_min-content] grid-rows-2 items-center' : 'question-closed grid-cols-[1fr_min-content] grid-rows-1 rounded-lg border border-[#DEE9F5] bg-[#FAFCFF]'}`}

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -225,6 +225,9 @@ const MiniCalendarView = ({
 				showNeighboringMonth={true}
 				showNavigation={false}
 				value={selectedDate}
+				tileClassName={({ date, view }) =>
+					isToday(date) ? 'react-calendar__tile--today' : ''
+				}
 				onClickDay={(value: Date) => {
 					const dateKey = formatValueTypeToYYYYMMDD(value);
 					const mood = moods[dateKey];

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -52,6 +52,8 @@ const MiniCalendarView = ({
 	const [moods, setMoods] = useState<{ [key: string]: string }>({});
 	const [isYearDropdownOpen, setYearDropdownOpen] = useState(false);
 	const [displayedYear, setDisplayedYear] = useState(new Date().getFullYear());
+	const [tempSelectedDate, setTempSelectedDate] = useState<Value>(selectedDate);
+
 	const today = new Date();
 	const todayYear = today.getFullYear();
 	const todayMonth = today.getMonth();
@@ -125,9 +127,9 @@ const MiniCalendarView = ({
 	}, [selectedDate]);
 
 	const changeMonth = (offset: number) => {
-		const newDate = new Date(selectedDate as Date);
+		const newDate = new Date(tempSelectedDate as Date);
 		newDate.setMonth(newDate.getMonth() + offset);
-		handleDateChange(newDate);
+		setTempSelectedDate(newDate);
 	};
 
 	const changeYear = () => {
@@ -152,117 +154,123 @@ const MiniCalendarView = ({
 
 	const handleMonthSelect = (month: number, event: React.MouseEvent) => {
 		event.stopPropagation();
-		const newDate = new Date(selectedDate as Date);
+		const newDate = new Date(tempSelectedDate as Date);
 		newDate.setMonth(month);
 		newDate.setFullYear(displayedYear);
-		handleDateChange(newDate);
+		setTempSelectedDate(newDate);
 		setYearDropdownOpen(false);
 		setMonth(month);
 	};
 
 	return (
 		<div className='mini-calendar flex w-64 flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
-			<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
-				<span
-					className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
-					onClick={changeYear}
-				>
-					{formatDateToMonth(selectedDate as Date)}{' '}
-					{formatDateToYear(selectedDate as Date)}
-					{isYearDropdownOpen ? (
-						<div className='calendar-dropdown'>
-							<div className='calendar-dropdown-year'>
-								<span className='text-sm font-semibold text-black'>
-									{displayedYear}
-								</span>
-								<div className='flex items-center justify-center gap-3 text-[#706F6F]'>
-									<button
-										className='hover:text-primary'
-										onClick={(event) => incrementYear(event)}
-									>
-										<CaretUp size={16} />
-									</button>
-									<button
-										className='hover:text-primary'
-										onClick={(event) => decrementYear(event)}
-									>
-										<CaretDown size={16} />
-									</button>
-								</div>
-							</div>
-							<div className='calendar-dropdown-months'>
-								{Array.from({ length: 12 }, (_, i) => i).map((month) => (
-									<button
-										key={month}
-										className={`calendar-dropdown-item ${new Date(selectedDate as Date).getMonth() === month ? 'selected-month' : ''}`}
-										onClick={(event) => handleMonthSelect(month, event)}
-									>
-										{new Date(0, month).toLocaleString('default', {
-											month: 'short',
-										})}
-									</button>
-								))}
-							</div>
-						</div>
-					) : null}
-				</span>
-				<div className='flex items-center justify-center gap-6'>
-					<button onClick={() => changeMonth(-1)}>
-						<CaretLeft weight='bold' className='text-primary' />
-					</button>
-					<button onClick={() => changeMonth(1)}>
-						<CaretRight weight='bold' className='text-primary' />
-					</button>
-				</div>
-			</div>
-			<Calendar
-				formatShortWeekday={(locale, date) =>
-					date.toLocaleString(locale, { weekday: 'narrow' })
-				}
-				key={`${(selectedDate instanceof Date ? selectedDate : new Date()).getMonth()}-${(selectedDate instanceof Date ? selectedDate : new Date()).getFullYear()}`}
-				calendarType='gregory'
-				onChange={handleDateChange}
-				showNeighboringMonth={true}
-				showNavigation={false}
-				value={selectedDate}
-				tileClassName={({ date, view }) =>
-					isToday(date) ? 'react-calendar__tile--today' : ''
-				}
-				onClickDay={(value: Date) => {
-					const dateKey = formatValueTypeToYYYYMMDD(value);
-					const mood = moods[dateKey];
-					const icon = mood
-						? `/moods/${mood.toLowerCase()}.svg`
-						: '/moods/greyWithFace.svg';
-					if (mood) {
-						handleLogClick({ date: value, mood, icon });
-					}
-				}}
-				tileContent={({ date, view }) => {
-					const dateKey = formatValueTypeToYYYYMMDD(date);
-					const mood = moods[dateKey]; // Check if a mood is logged for this date
-					const backgroundColor =
-						mood && colors.hasOwnProperty(mood)
-							? colors[mood as Mood]
-							: 'transparent';
-					const icon = mood
-						? `/moods/${mood.toLowerCase()}.svg`
-						: '/moods/greyWithFace.svg';
-					return (
+			{!isYearDropdownOpen ? (
+				<>
+					<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
 						<span
-							className='mb-1 flex h-[0.25rem] w-[0.25rem] rounded-full'
-							style={{ backgroundColor }}
-						></span>
-					);
-				}}
-				tileDisabled={({ date, view }) =>
-					date.getFullYear() > todayYear ||
-					(date.getFullYear() === todayYear && date.getMonth() > todayMonth) ||
-					(date.getFullYear() === todayYear &&
-						date.getMonth() === todayMonth &&
-						date.getDate() > todayDate)
-				}
-			/>
+							className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
+							onClick={changeYear}
+						>
+							{formatDateToMonth(tempSelectedDate as Date)}{' '}
+							{formatDateToYear(tempSelectedDate as Date)}
+						</span>
+						<div className='flex items-center justify-center gap-6'>
+							<button onClick={() => changeMonth(-1)}>
+								<CaretLeft weight='bold' className='text-primary' />
+							</button>
+							<button onClick={() => changeMonth(1)}>
+								<CaretRight weight='bold' className='text-primary' />
+							</button>
+						</div>
+					</div>
+					<Calendar
+						formatShortWeekday={(locale, date) =>
+							date.toLocaleString(locale, { weekday: 'narrow' })
+						}
+						key={`${(tempSelectedDate instanceof Date ? tempSelectedDate : new Date()).getMonth()}-${(tempSelectedDate instanceof Date ? tempSelectedDate : new Date()).getFullYear()}`}
+						calendarType='gregory'
+						onChange={handleDateChange}
+						showNeighboringMonth={true}
+						showNavigation={false}
+						value={tempSelectedDate}
+						tileClassName={({ date, view }) =>
+							isToday(date) ? 'react-calendar__tile--today' : ''
+						}
+						onClickDay={(value: Date) => {
+							const dateKey = formatValueTypeToYYYYMMDD(value);
+							const mood = moods[dateKey];
+							const icon = mood
+								? `/moods/${mood.toLowerCase()}.svg`
+								: '/moods/greyWithFace.svg';
+							if (mood) {
+								handleLogClick({ date: value, mood, icon });
+							}
+							setTempSelectedDate(value);
+							handleDateChange(value);
+						}}
+						tileContent={({ date, view }) => {
+							const dateKey = formatValueTypeToYYYYMMDD(date);
+							const mood = moods[dateKey]; // Check if a mood is logged for this date
+							const backgroundColor =
+								mood && colors.hasOwnProperty(mood)
+									? colors[mood as Mood]
+									: 'transparent';
+							const icon = mood
+								? `/moods/${mood.toLowerCase()}.svg`
+								: '/moods/greyWithFace.svg';
+							return (
+								<span
+									className='mb-1 flex h-[0.25rem] w-[0.25rem] rounded-full'
+									style={{ backgroundColor }}
+								></span>
+							);
+						}}
+						tileDisabled={({ date, view }) =>
+							date.getFullYear() > todayYear ||
+							(date.getFullYear() === todayYear &&
+								date.getMonth() > todayMonth) ||
+							(date.getFullYear() === todayYear &&
+								date.getMonth() === todayMonth &&
+								date.getDate() > todayDate)
+						}
+					/>
+				</>
+			) : (
+				<div className='mini-calendar mini-calendar-dropdown'>
+					<div className='mini-calendar-dropdown-year'>
+						<span className='text-sm font-semibold text-black'>
+							{displayedYear}
+						</span>
+						<div className='flex items-center justify-center gap-3 text-[#706F6F]'>
+							<button
+								className='hover:text-primary'
+								onClick={(event) => incrementYear(event)}
+							>
+								<CaretUp size={16} weight='bold' className='text-primary' />
+							</button>
+							<button
+								className='hover:text-primary'
+								onClick={(event) => decrementYear(event)}
+							>
+								<CaretDown size={16} weight='bold' className='text-primary' />
+							</button>
+						</div>
+					</div>
+					<div className='mini-calendar-dropdown-months'>
+						{Array.from({ length: 12 }, (_, i) => i).map((month) => (
+							<button
+								key={month}
+								className={`calendar-dropdown-item ${new Date(tempSelectedDate as Date).getMonth() === month ? 'selected-month' : ''}`}
+								onClick={(event) => handleMonthSelect(month, event)}
+							>
+								{new Date(0, month).toLocaleString('default', {
+									month: 'short',
+								})}
+							</button>
+						))}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -161,10 +161,10 @@ const MiniCalendarView = ({
 	};
 
 	return (
-		<div className='mini-calendar flex w-full flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
-			<div className='calendar-nav flex flex-row justify-between gap-2 pr-2'>
+		<div className='mini-calendar flex w-64 flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
+			<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
 				<span
-					className={`calendar-heading align-center flex cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
+					className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
 					onClick={changeYear}
 				>
 					{formatDateToMonth(selectedDate as Date)}{' '}

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Calendar from 'react-calendar';
-
+import { ReflectionsType } from '@/components/home/newLogPopup';
 import { useAuth } from '@/app/context/UserProvider';
 import { getUser, addUserMood } from '../utils/serverFunctions';
 import '/app/styles/miniCalendar.css';
@@ -27,7 +27,12 @@ type Props = {
 	value: Value | null;
 	setValue: React.Dispatch<React.SetStateAction<Value | null>>;
 	handleDateChange: (newValue: Value) => void;
-	handleLogClick: (log: { date: Date; mood: string; icon: string }) => void;
+	handleLogClick: (log: {
+		date: Date;
+		mood: string;
+		icon: string;
+		reflections?: ReflectionsType[];
+	}) => void;
 };
 
 type ValuePiece = Date | null;


### PR DESCRIPTION
## Description

**Addressing various issues related to the mini-calendar.**
1) Make today's date in the mini calendar always have the dark blue background/white text, and other selections have a lighter blue background/dark blue text (#44 ).
2) Fix the padding between the dots and the tiles (#35 ).
3) The mini calendar width was increased to 16rem so that the month and year always fit on the same line. The wireframe has it at 14.125rem, but it's not enough for the longer month names (e.g., September) (#43 ). 
4) When the user clicks on the month-year (e.g. May 2024), the calendar options replace the mini-calendar, instead of as a drop-down overlaid on the mini-calendar (#40 ).
5) When the user changes the month in the mini calendar, big calendar doesn't change until the user selects a specific date on the mini calendar (#42 ).

## Related Issue

[#44 Suggesting a style update: Today's date and Selection date on mini calendar](https://github.com/cherryontech/jupiter-jumpers/issues/44)

[#35  Style Update: Increase padding in mini calendar.](https://github.com/cherryontech/jupiter-jumpers/issues/35)

[#43 The date and month should be on the same line for all the months.](https://github.com/cherryontech/jupiter-jumpers/issues/43)

[#40 Suggesting a style update: Mini Calendar change from Month to Year.](https://github.com/cherryontech/jupiter-jumpers/issues/40)

[#42  Bug: Mini Calendar and Big calendar interaction. ](https://github.com/cherryontech/jupiter-jumpers/issues/42)

## Related Story Card

N/A

## Type of Changes

Style Updates

## Acceptance Criteria

_Include the checked-off acceptance criteria from the issue._

## Update Screenshots

![Screenshot 2024-05-22 at 1 41 04 PM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/ca5f560d-c8b9-4ef2-99c6-23efef41729a)
![Screenshot 2024-05-22 at 1 41 31 PM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/857e84c7-1469-4e0e-a6e7-8d6f56c8a941)

### Before

### After

## Testing Instructions

- [ ] Ensure today's date in the mini calendar always has the dark blue background/white text, and other selections have a lighter blue background/dark blue text (#44 ).
- [ ] Ensure there is adequate padding between the colored dots and the tiles (#35 ).
- [ ] In the mini calendar, switch the months using the carets and ensure that the month and year always stay on a single line (it doesn't wrap to a second line). 
- [ ] Click on "May 2024". Ensure that the options to change months/years replaces the mini-calendar (it's not overlaid). 
- [ ] Click on "May 2024". Ensure that when you click on a month, that the month shows up in the mini-calendar, and that the main calendar does not update until you select an actual date.

## Learnings (Optional)

_Document any things you learned or 'gotchas' you experienced._
