### PR TITLE
Addressing More Issues

### DIFF
--- a/app/mainComponent.tsx
+++ b/app/mainComponent.tsx
@@ -27,6 +27,7 @@ export default function MainComponent({
 	const [value, setValue] = useState<Value | null>(new Date());
 	const [isPopupOpen, setPopupOpen] = useState(false);
 	const [month, setMonth] = useState(new Date().getMonth());
+	const [isSummaryList, setIsSummaryList] = useState(true);
 	const [isRightBarOpen, setRightBarOpen] = useState(true);
 	const [selectedLog, setSelectedLog] = useState<{
 		date: Date;
@@ -43,6 +44,7 @@ export default function MainComponent({
 		icon: string;
 		reflections?: ReflectionsType[];
 	}) => {
+		setIsSummaryList(false);
 		setRightBarHistory((prevHistory) =>
 			rightBarContent ? [...prevHistory, rightBarContent] : prevHistory
 		);
@@ -61,7 +63,7 @@ export default function MainComponent({
 	};
 
 	const handleGoBack = () => {
-		console.log('Go back clicked');
+		setIsSummaryList(true);
 		setRightBarContent(
 			<LogSummaryList
 				handleLogClick={handleLogClick}
@@ -69,6 +71,8 @@ export default function MainComponent({
 				value={value}
 				setValue={setValue}
 				handleDateChange={handleDateChange}
+				currentPage={currentPage}
+				handlePagination={handlePagination}
 			/>
 		);
 	};
@@ -135,6 +139,13 @@ export default function MainComponent({
 			);
 	}
 	console.log('User', user);
+
+	const [currentPage, setCurrentPage] = useState(1);
+
+	const handlePagination = (value: { selected: number }) => {
+		setCurrentPage(value.selected + 1);
+	};
+
 	return (
 		<div className='grid-container'>
 			<div className='sidebar border-r-[0.0625rem] border-[#D9D9D9]'>
@@ -171,6 +182,7 @@ export default function MainComponent({
 						</div>
 					</div>
 					<Rightbar
+						month={month}
 						isRightBarOpen={isRightBarOpen}
 						onToggle={handleRightBarToggle}
 						handleLogClick={handleLogClick}
@@ -178,6 +190,9 @@ export default function MainComponent({
 						value={value}
 						setValue={setValue}
 						handleDateChange={handleDateChange}
+						currentPage={currentPage}
+						handlePagination={handlePagination}
+						isSummaryList={isSummaryList}
 					>
 						{rightBarContent}
 					</Rightbar>

--- a/app/styles/miniCalendar.css
+++ b/app/styles/miniCalendar.css
@@ -235,23 +235,15 @@
 .mini-calendar .calendar-heading.dropdown-open {
 	background-color: #dee9f5;
 }
-.mini-calendar .calendar-dropdown {
-	position: absolute;
-	top: 120%;
-	left: 0%;
+.mini-calendar .mini-calendar-dropdown {
 	background-color: white;
-	border: 1px solid #dee9f5;
-	padding: 0.75rem;
-	z-index: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	gap: 0.75rem;
-	width: fit-content;
-	border-radius: 0.5rem;
-	box-shadow: 0px 15px 20px 0px rgba(0, 0, 0, 0.03);
+	width: 100%;
 }
-.mini-calendar .calendar-dropdown-year {
+.mini-calendar .mini-calendar-dropdown-year {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -260,10 +252,11 @@
 	font-size: 0.875rem;
 	padding: 0 0.375rem;
 }
-.mini-calendar .calendar-dropdown-months {
+.mini-calendar .mini-calendar-dropdown-months {
 	display: grid;
 	grid-template-columns: repeat(4, 1fr);
 	gap: 0.75rem;
+	width: 100%;
 }
 .mini-calendar .calendar-dropdown-item {
 	display: flex;

--- a/app/styles/miniCalendar.css
+++ b/app/styles/miniCalendar.css
@@ -96,6 +96,11 @@
 	/* bottom: 1rem; */
 }
 .mini-calendar .react-calendar__tile--active abbr {
+	background: #dee9f5;
+	color: #2d81e0;
+}
+
+.mini-calendar .react-calendar__tile--today abbr {
 	background: #2d81e0;
 	color: white;
 }
@@ -157,6 +162,7 @@
 	font-weight: 400;
 	overflow: visible !important;
 	padding: 0.1rem;
+	gap: 0.3rem;
 }
 
 .mini-calendar .react-calendar__tile {
@@ -286,4 +292,8 @@
 	height: 0.5rem;
 	border-radius: 50%;
 	background-color: #2d81e0;
+}
+
+.today {
+	background-color: blue !important;
 }

--- a/components/home/calendar.tsx
+++ b/components/home/calendar.tsx
@@ -195,9 +195,6 @@ const CalendarView = ({
 			<div className='flex max-h-24 flex-col gap-5'>
 				<div className='flex min-h-12 w-full flex-row items-center justify-between font-semibold'>
 					<div className='calendar-nav flex flex-row gap-2'>
-						<button onClick={() => changeMonth(-1)}>
-							<CaretLeft weight='bold' className='text-primary' />
-						</button>
 						<span
 							className={`calendar-heading align-center flex cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-2xl ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
 							onClick={changeYear}
@@ -241,6 +238,9 @@ const CalendarView = ({
 								</div>
 							) : null}
 						</span>
+						<button onClick={() => changeMonth(-1)}>
+							<CaretLeft weight='bold' className='text-primary' />
+						</button>
 						<button onClick={() => changeMonth(1)}>
 							<CaretRight weight='bold' className='text-primary' />
 						</button>

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -76,7 +76,7 @@ const LogSummary: React.FC<LogSummaryProps> = ({ log, handleGoBack }) => {
 				{/* Divider */}
 				<div className='h-[0.125rem] bg-[#dee9f5]'></div>
 			</div>
-			<div className='flex h-full flex-col overflow-scroll'>
+			<div className='flex h-full flex-col overflow-scroll px-3'>
 				{/* Icon and Mood Name */}
 				<div className='flex flex-col items-center justify-center gap-4 py-10'>
 					<div className='rounded-xl border border-[#DEE9F5] bg-[#FAFCFF]'>

--- a/components/shared/logSummaryList.tsx
+++ b/components/shared/logSummaryList.tsx
@@ -24,11 +24,15 @@ type LogSummaryListProps = {
 	value: Value | null;
 	setValue: React.Dispatch<React.SetStateAction<Value | null>>;
 	handleDateChange: (newValue: Value) => void;
+	currentPage: number;
+	handlePagination: (value: { selected: number }) => void;
 };
 
 const LogSummaryList: React.FC<LogSummaryListProps> = ({
 	handleLogClick,
 	handleDateChange,
+	currentPage,
+	handlePagination,
 }) => {
 	const { user, isUpdated } = useAuth();
 	const [moods, setMoods] = useState<{
@@ -41,16 +45,12 @@ const LogSummaryList: React.FC<LogSummaryListProps> = ({
 		Rainy: false,
 		Stormy: false,
 	});
-	const [currentPage, setCurrentPage] = useState(1);
+
 	const handleCheckboxChange = (filter: string) => {
 		setSelectedFilters((prevState) => ({
 			...prevState,
 			[filter]: !prevState[filter as keyof typeof selectedFilters],
 		}));
-	};
-
-	const handlePagination = (value: { selected: number }) => {
-		setCurrentPage(value.selected + 1);
 	};
 
 	useEffect(() => {

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -225,6 +225,9 @@ const MiniCalendarView = ({
 				showNeighboringMonth={true}
 				showNavigation={false}
 				value={selectedDate}
+				tileClassName={({ date, view }) =>
+					isToday(date) ? 'react-calendar__tile--today' : ''
+				}
 				onClickDay={(value: Date) => {
 					const dateKey = formatValueTypeToYYYYMMDD(value);
 					const mood = moods[dateKey];

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -52,6 +52,8 @@ const MiniCalendarView = ({
 	const [moods, setMoods] = useState<{ [key: string]: string }>({});
 	const [isYearDropdownOpen, setYearDropdownOpen] = useState(false);
 	const [displayedYear, setDisplayedYear] = useState(new Date().getFullYear());
+	const [tempSelectedDate, setTempSelectedDate] = useState<Value>(selectedDate);
+
 	const today = new Date();
 	const todayYear = today.getFullYear();
 	const todayMonth = today.getMonth();
@@ -125,9 +127,9 @@ const MiniCalendarView = ({
 	}, [selectedDate]);
 
 	const changeMonth = (offset: number) => {
-		const newDate = new Date(selectedDate as Date);
+		const newDate = new Date(tempSelectedDate as Date);
 		newDate.setMonth(newDate.getMonth() + offset);
-		handleDateChange(newDate);
+		setTempSelectedDate(newDate);
 	};
 
 	const changeYear = () => {
@@ -152,117 +154,123 @@ const MiniCalendarView = ({
 
 	const handleMonthSelect = (month: number, event: React.MouseEvent) => {
 		event.stopPropagation();
-		const newDate = new Date(selectedDate as Date);
+		const newDate = new Date(tempSelectedDate as Date);
 		newDate.setMonth(month);
 		newDate.setFullYear(displayedYear);
-		handleDateChange(newDate);
+		setTempSelectedDate(newDate);
 		setYearDropdownOpen(false);
 		setMonth(month);
 	};
 
 	return (
 		<div className='mini-calendar flex w-64 flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
-			<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
-				<span
-					className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
-					onClick={changeYear}
-				>
-					{formatDateToMonth(selectedDate as Date)}{' '}
-					{formatDateToYear(selectedDate as Date)}
-					{isYearDropdownOpen ? (
-						<div className='calendar-dropdown'>
-							<div className='calendar-dropdown-year'>
-								<span className='text-sm font-semibold text-black'>
-									{displayedYear}
-								</span>
-								<div className='flex items-center justify-center gap-3 text-[#706F6F]'>
-									<button
-										className='hover:text-primary'
-										onClick={(event) => incrementYear(event)}
-									>
-										<CaretUp size={16} />
-									</button>
-									<button
-										className='hover:text-primary'
-										onClick={(event) => decrementYear(event)}
-									>
-										<CaretDown size={16} />
-									</button>
-								</div>
-							</div>
-							<div className='calendar-dropdown-months'>
-								{Array.from({ length: 12 }, (_, i) => i).map((month) => (
-									<button
-										key={month}
-										className={`calendar-dropdown-item ${new Date(selectedDate as Date).getMonth() === month ? 'selected-month' : ''}`}
-										onClick={(event) => handleMonthSelect(month, event)}
-									>
-										{new Date(0, month).toLocaleString('default', {
-											month: 'short',
-										})}
-									</button>
-								))}
-							</div>
-						</div>
-					) : null}
-				</span>
-				<div className='flex items-center justify-center gap-6'>
-					<button onClick={() => changeMonth(-1)}>
-						<CaretLeft weight='bold' className='text-primary' />
-					</button>
-					<button onClick={() => changeMonth(1)}>
-						<CaretRight weight='bold' className='text-primary' />
-					</button>
-				</div>
-			</div>
-			<Calendar
-				formatShortWeekday={(locale, date) =>
-					date.toLocaleString(locale, { weekday: 'narrow' })
-				}
-				key={`${(selectedDate instanceof Date ? selectedDate : new Date()).getMonth()}-${(selectedDate instanceof Date ? selectedDate : new Date()).getFullYear()}`}
-				calendarType='gregory'
-				onChange={handleDateChange}
-				showNeighboringMonth={true}
-				showNavigation={false}
-				value={selectedDate}
-				tileClassName={({ date, view }) =>
-					isToday(date) ? 'react-calendar__tile--today' : ''
-				}
-				onClickDay={(value: Date) => {
-					const dateKey = formatValueTypeToYYYYMMDD(value);
-					const mood = moods[dateKey];
-					const icon = mood
-						? `/moods/${mood.toLowerCase()}.svg`
-						: '/moods/greyWithFace.svg';
-					if (mood) {
-						handleLogClick({ date: value, mood, icon });
-					}
-				}}
-				tileContent={({ date, view }) => {
-					const dateKey = formatValueTypeToYYYYMMDD(date);
-					const mood = moods[dateKey]; // Check if a mood is logged for this date
-					const backgroundColor =
-						mood && colors.hasOwnProperty(mood)
-							? colors[mood as Mood]
-							: 'transparent';
-					const icon = mood
-						? `/moods/${mood.toLowerCase()}.svg`
-						: '/moods/greyWithFace.svg';
-					return (
+			{!isYearDropdownOpen ? (
+				<>
+					<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
 						<span
-							className='mb-1 flex h-[0.25rem] w-[0.25rem] rounded-full'
-							style={{ backgroundColor }}
-						></span>
-					);
-				}}
-				tileDisabled={({ date, view }) =>
-					date.getFullYear() > todayYear ||
-					(date.getFullYear() === todayYear && date.getMonth() > todayMonth) ||
-					(date.getFullYear() === todayYear &&
-						date.getMonth() === todayMonth &&
-						date.getDate() > todayDate)
-				}
-			/>
+							className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
+							onClick={changeYear}
+						>
+							{formatDateToMonth(tempSelectedDate as Date)}{' '}
+							{formatDateToYear(tempSelectedDate as Date)}
+						</span>
+						<div className='flex items-center justify-center gap-6'>
+							<button onClick={() => changeMonth(-1)}>
+								<CaretLeft weight='bold' className='text-primary' />
+							</button>
+							<button onClick={() => changeMonth(1)}>
+								<CaretRight weight='bold' className='text-primary' />
+							</button>
+						</div>
+					</div>
+					<Calendar
+						formatShortWeekday={(locale, date) =>
+							date.toLocaleString(locale, { weekday: 'narrow' })
+						}
+						key={`${(tempSelectedDate instanceof Date ? tempSelectedDate : new Date()).getMonth()}-${(tempSelectedDate instanceof Date ? tempSelectedDate : new Date()).getFullYear()}`}
+						calendarType='gregory'
+						onChange={handleDateChange}
+						showNeighboringMonth={true}
+						showNavigation={false}
+						value={tempSelectedDate}
+						tileClassName={({ date, view }) =>
+							isToday(date) ? 'react-calendar__tile--today' : ''
+						}
+						onClickDay={(value: Date) => {
+							const dateKey = formatValueTypeToYYYYMMDD(value);
+							const mood = moods[dateKey];
+							const icon = mood
+								? `/moods/${mood.toLowerCase()}.svg`
+								: '/moods/greyWithFace.svg';
+							if (mood) {
+								handleLogClick({ date: value, mood, icon });
+							}
+							setTempSelectedDate(value);
+							handleDateChange(value);
+						}}
+						tileContent={({ date, view }) => {
+							const dateKey = formatValueTypeToYYYYMMDD(date);
+							const mood = moods[dateKey]; // Check if a mood is logged for this date
+							const backgroundColor =
+								mood && colors.hasOwnProperty(mood)
+									? colors[mood as Mood]
+									: 'transparent';
+							const icon = mood
+								? `/moods/${mood.toLowerCase()}.svg`
+								: '/moods/greyWithFace.svg';
+							return (
+								<span
+									className='mb-1 flex h-[0.25rem] w-[0.25rem] rounded-full'
+									style={{ backgroundColor }}
+								></span>
+							);
+						}}
+						tileDisabled={({ date, view }) =>
+							date.getFullYear() > todayYear ||
+							(date.getFullYear() === todayYear &&
+								date.getMonth() > todayMonth) ||
+							(date.getFullYear() === todayYear &&
+								date.getMonth() === todayMonth &&
+								date.getDate() > todayDate)
+						}
+					/>
+				</>
+			) : (
+				<div className='mini-calendar mini-calendar-dropdown'>
+					<div className='mini-calendar-dropdown-year'>
+						<span className='text-sm font-semibold text-black'>
+							{displayedYear}
+						</span>
+						<div className='flex items-center justify-center gap-3 text-[#706F6F]'>
+							<button
+								className='hover:text-primary'
+								onClick={(event) => incrementYear(event)}
+							>
+								<CaretUp size={16} weight='bold' className='text-primary' />
+							</button>
+							<button
+								className='hover:text-primary'
+								onClick={(event) => decrementYear(event)}
+							>
+								<CaretDown size={16} weight='bold' className='text-primary' />
+							</button>
+						</div>
+					</div>
+					<div className='mini-calendar-dropdown-months'>
+						{Array.from({ length: 12 }, (_, i) => i).map((month) => (
+							<button
+								key={month}
+								className={`calendar-dropdown-item ${new Date(tempSelectedDate as Date).getMonth() === month ? 'selected-month' : ''}`}
+								onClick={(event) => handleMonthSelect(month, event)}
+							>
+								{new Date(0, month).toLocaleString('default', {
+									month: 'short',
+								})}
+							</button>
+						))}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -161,10 +161,10 @@ const MiniCalendarView = ({
 	};
 
 	return (
-		<div className='mini-calendar flex w-full flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
-			<div className='calendar-nav flex flex-row justify-between gap-2 pr-2'>
+		<div className='mini-calendar flex w-64 flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
+			<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
 				<span
-					className={`calendar-heading align-center flex cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
+					className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-3 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
 					onClick={changeYear}
 				>
 					{formatDateToMonth(selectedDate as Date)}{' '}


### PR DESCRIPTION
## Description

1) Addresses #39 - Moves the left chevron/caret to the right of "May 2024" (Month Year) (e.g., < >)
2) Addresses #34 - Pagination was showing up for the daily view; it now only shows up when the summary list is visible.
3) Addresses #36 - Adds padding to the log summary (daily view) so that when you're scrolling the scroll bar is not overlaid on the content.

## Related Issue

[ #39 Suggesting a style update: Moving the left chevorn](https://github.com/cherryontech/jupiter-jumpers/issues/39)

[#34  Style Update: Remove pagination from daily view.](https://github.com/cherryontech/jupiter-jumpers/issues/34)
[#36 Styling Update: Add padding to account for scrollbar. ](https://github.com/cherryontech/jupiter-jumpers/issues/36)


## Related Story Card

N/A

## Type of Changes
Styling updates.

## Acceptance Criteria

N/A

## Update Screenshots

### After
![Screenshot 2024-05-22 at 3 52 30 PM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/28468530-9aa7-4a98-aeed-56293e21d782)

## Testing Instructions

1) Ensure the carets (arrows) appear to the right of "May 2024" (or whatever month/year combo) and still work to switch the month.
2) Make sure pagination only shows up when the summary list is visible (not for the daily views)
3) Minimize the window vertically so that scrolling is required in the daily view of one of the logs, and ensure the scroll bar has enough space (it's not over top of any content).

## Learnings (Optional)

_Document any things you learned or 'gotchas' you experienced._
