### PR TITLE
Style fixes

### DIFF
--- a/app/mainComponent.tsx
+++ b/app/mainComponent.tsx
@@ -83,6 +83,8 @@ export default function MainComponent({
 		null
 	);
 	const [rightBarHistory, setRightBarHistory] = useState<JSX.Element[]>([]);
+	const [logUpdate, setLogUpdate] = useState(false);
+
 	const handleLogClick = (log: {
 		date: Date;
 		mood: string;
@@ -91,6 +93,8 @@ export default function MainComponent({
 		favorite: boolean;
 		wins?: Win[];
 	}) => {
+		setLogUpdate((prevState) => !prevState);
+
 		setIsSummaryList(false);
 		setRightBarHistory((prevHistory) =>
 			rightBarContent ? [...prevHistory, rightBarContent] : prevHistory
@@ -119,9 +123,7 @@ export default function MainComponent({
 
 	const handleGoBack = () => {
 		setIsSummaryList(true);
-		setRightBarContent(
-			null
-		);
+		setRightBarContent(null);
 	};
 
 	const handlePopupToggle = useCallback(() => {
@@ -190,14 +192,14 @@ export default function MainComponent({
 				/>
 			);
 	}
-	
+
 	const [currentPage, setCurrentPage] = useState(1);
 
 	const handlePagination = (value: { selected: number }) => {
 		setCurrentPage(value.selected + 1);
 	};
-console.log(month);
-console.log(selectedDate);
+	console.log(month);
+	console.log(selectedDate);
 	return (
 		<div className='grid-container'>
 			<div className='sidebar border-r-[0.0625rem] border-[#D9D9D9]'>
@@ -214,6 +216,7 @@ console.log(selectedDate);
 							setValue={setValue}
 							handleDateChange={handleDateChange}
 							handleLogClick={handleLogClick}
+							logUpdate={logUpdate}
 						/>
 					}
 				/>

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -90,8 +90,8 @@
 
 abbr {
 	position: initial;
-	height: 1.5rem;
-	width: 1.5rem;
+	min-height: 1.5rem;
+	min-width: 1.5rem;
 	text-decoration: none;
 	display: flex;
 	justify-content: center;

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -25,7 +25,7 @@
 	grid-column: 1 / -1;
 	display: grid;
 	/* height: 95%; */
-	grid-template-columns: 2fr 1fr;
+	grid-template-columns: 2fr auto;
 	gap: 1rem;
 	margin-right: 1rem;
 	/* margin-bottom: 6rem; */

--- a/app/styles/miniCalendar.css
+++ b/app/styles/miniCalendar.css
@@ -79,8 +79,8 @@
 
 .mini-calendar abbr {
 	position: initial;
-	height: 1.5rem;
-	width: 1.5rem;
+	min-height: 1.5rem;
+	min-width: 1.5rem;
 	text-decoration: none;
 	display: flex;
 	justify-content: center;

--- a/components/home/calendar.tsx
+++ b/components/home/calendar.tsx
@@ -20,6 +20,7 @@ import {
 	ArrowUp,
 	ArrowDown,
 } from '@phosphor-icons/react';
+import todayIcon from '/public/moods/today.svg';
 
 import '/app/styles/calendar.css';
 import { init } from 'next/dist/compiled/webpack/webpack';
@@ -54,7 +55,7 @@ export type MoodEntry = {
 	mood: string;
 	reflections: ReflectionsType[];
 	favorite: boolean;
-	wins:Win[]
+	wins: Win[];
 };
 
 const CalendarView = ({
@@ -76,7 +77,7 @@ const CalendarView = ({
 			mood: string;
 			reflections: ReflectionsType[];
 			favorite: boolean;
-      wins:Win[]
+			wins: Win[];
 		};
 	}>({});
 	const [isYearDropdownOpen, setYearDropdownOpen] = useState(false);
@@ -91,7 +92,7 @@ const CalendarView = ({
 							mood: string;
 							reflections: ReflectionsType[];
 							favorite: boolean;
-              wins:Win[]
+							wins: Win[];
 						};
 					} = {};
 
@@ -144,7 +145,7 @@ const CalendarView = ({
 		mood: string,
 		reflections: ReflectionsType[],
 		favorite: boolean,
-     		wins:Win[]
+		wins: Win[]
 	) => {
 		if (user) {
 			await addUserMood(user.uid, mood, date, reflections, favorite, wins);
@@ -157,7 +158,7 @@ const CalendarView = ({
 				icon: `/moods/${mood.toLowerCase()}.svg`,
 				reflections: reflections,
 				favorite: favorite,
-				wins:wins
+				wins: wins,
 			});
 		}
 	};
@@ -349,7 +350,7 @@ const CalendarView = ({
 						/>
 					) : (
 						<Image
-							src={`/moods/greyWithFace.svg`}
+							src={isDateToday ? todayIcon : `/moods/greyWithFace.svg`}
 							alt='Mood'
 							height={150}
 							width={150}
@@ -357,7 +358,7 @@ const CalendarView = ({
 								handleLogClick({
 									date: date,
 									mood: 'No Log Yet',
-									icon: '/moods/greyWithFace.svg',
+									icon: isDateToday ? todayIcon : '/moods/greyWithFace.svg',
 									reflections: [],
 									favorite: false,
 									wins: [],

--- a/components/home/moodPrompts.tsx
+++ b/components/home/moodPrompts.tsx
@@ -140,7 +140,9 @@ const MoodPrompts = ({
 				<div className='h-20 w-20 rounded-md bg-gray-300'></div>
 				<div className='text-left'>
 					<p className='text-2xl font-bold'>3 Wins of the Day</p>
-					<p className='text-sm'>Get specific! use details to describe what you accomplished today.</p>
+					<p className='text-sm'>
+						Get specific! use details to describe what you accomplished today.
+					</p>
 				</div>
 			</div>
 

--- a/components/shared/dropDown.tsx
+++ b/components/shared/dropDown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { CaretDown, CaretUp, SignOut, User, Gear } from '@phosphor-icons/react';
 import { signOut } from 'firebase/auth';
 import { useRouter } from 'next/navigation';
@@ -19,6 +19,7 @@ type DropdownProps = {
 export default function Dropdown({ user }: DropdownProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const router = useRouter();
+	const dropdownRef = useRef<HTMLDivElement>(null);
 
 	const handleLogOut = () => {
 		signOut(auth)
@@ -31,10 +32,27 @@ export default function Dropdown({ user }: DropdownProps) {
 			});
 	};
 
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				dropdownRef.current &&
+				!dropdownRef.current.contains(event.target as Node)
+			) {
+				setIsOpen(false);
+			}
+		};
+
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, []);
+
 	const menu = {
 		Account: { url: '#', icon: <User size={24} /> },
 		Settings: { url: '#', icon: <Gear size={24} /> },
 	};
+
 	return (
 		<div className='dropdown w-full'>
 			<button
@@ -52,7 +70,10 @@ export default function Dropdown({ user }: DropdownProps) {
 			</button>
 
 			{isOpen && (
-				<div className='dropdown-content flex w-full flex-col rounded-md bg-[#F3F5F9] py-2'>
+				<div
+					ref={dropdownRef}
+					className='dropdown-content flex w-full flex-col rounded-md bg-[#F3F5F9] py-2'
+				>
 					{/* Add links */}
 					{Object.entries(menu).map(([text, { url, icon }]) => (
 						<a href={url} key={text}>

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -89,7 +89,7 @@ const LogSummary: React.FC<LogSummaryProps> = ({
 	return (
 		<>
 			<div className='flex max-h-24 flex-col gap-5 pb-4'>
-				<div className='flex w-full flex-row items-center justify-between  px-1 text-base font-semibold'>
+				<div className='flex w-full flex-row items-center justify-between gap-4  px-1 text-base font-semibold'>
 					<div className='flex flex-row gap-2 text-primary'>
 						<button
 							onClick={handleGoBack}

--- a/components/shared/logSummary.tsx
+++ b/components/shared/logSummary.tsx
@@ -12,7 +12,6 @@ import { getUser, updateFavorite } from '../utils/serverFunctions';
 import { on } from 'events';
 import { Win } from '../home/moodPrompts';
 
-
 interface LogSummaryProps {
 	log: {
 		date: Date;
@@ -53,18 +52,6 @@ const LogSummary: React.FC<LogSummaryProps> = ({
 
 	const { user, isUpdated } = useAuth();
 
-	const wins = [
-		{
-			title: 'I made a resume today',
-			description: 'I created a template and updated my job list',
-		},
-		{
-			title: 'I read 3 chapters',
-			description: 'I started reading a new job search book',
-		},
-		{ title: 'I updated my LinkedIn', description: 'I redid my coverpage' },
-	];
-
 	const [openReflections, setOpenReflections] = useState<number[]>([]);
 
 	console.log(isUpdated);
@@ -96,6 +83,8 @@ const LogSummary: React.FC<LogSummaryProps> = ({
 				: [...prevState, index]
 		);
 	};
+
+	const nonEmptyWins = log.wins.filter((win) => win.description.trim() !== '');
 
 	return (
 		<>
@@ -143,23 +132,23 @@ const LogSummary: React.FC<LogSummaryProps> = ({
 					</div>
 				</div>
 
-				{log.wins.length > 0 && (
-					<div className='flex flex-col gap-3'>
-						<span className='text-sm font-semibold'>3 Wins</span>
-						<div>
-							{log.wins.map((win, index) => (
+				{log.wins.some((win) => win.description.trim() !== '') && (
+					<div className='flex flex-col gap-3 '>
+						<span className='text-sm font-semibold'>My Wins</span>
+						<div className='pl-[1.62rem]'>
+							{nonEmptyWins.map((win, index) => (
 								<div
 									key={index}
-									className='relative flex h-fit flex-row items-center justify-start gap-3'
+									className='relative flex h-fit flex-row items-center justify-start gap-3 '
 								>
-									<div className='absolute bottom-0 left-0 top-2 flex flex-col items-center gap-1'>
+									<div className='absolute bottom-0 left-0 top-1 flex flex-col items-center gap-1'>
 										<div className='h-2 w-2 rounded-full bg-primary'></div>
-										{index !== wins.length - 1 && (
-											<div className='w-[1px] flex-grow bg-[#DEE9F5]'></div>
+										{index !== nonEmptyWins.length - 1 && (
+											<div className='w-[0.125rem] flex-grow bg-[#DEE9F5]'></div>
 										)}
 									</div>
 									<div className='ml-3 flex flex-col justify-start pb-8 pl-3'>
-										<span className='text-xs font-normal text-[#706F6F]'>
+										<span className='text-sm font-semibold text-[#2C2C2C]'>
 											{win.description}
 										</span>
 									</div>

--- a/components/shared/logSummaryList.tsx
+++ b/components/shared/logSummaryList.tsx
@@ -36,7 +36,7 @@ const LogSummaryList: React.FC<LogSummaryListProps> = ({
 	handleDateChange,
 	currentPage,
 	handlePagination,
-	selectedDate
+	selectedDate,
 }) => {
 	const { user, isUpdated } = useAuth();
 	const [moods, setMoods] = useState<{
@@ -44,7 +44,7 @@ const LogSummaryList: React.FC<LogSummaryListProps> = ({
 			mood: string;
 			reflections: ReflectionsType[];
 			favorite: boolean;
-      wins: Win[]
+			wins: Win[];
 		};
 	}>({});
 	const [selectedFilters, setSelectedFilters] = useState({
@@ -61,7 +61,7 @@ const LogSummaryList: React.FC<LogSummaryListProps> = ({
 			[filter]: !prevState[filter as keyof typeof selectedFilters],
 		}));
 	};
-console.log(currentPage);
+	console.log(currentPage);
 	useEffect(() => {
 		if (user) {
 			getUser(user.uid).then((userData) => {
@@ -71,7 +71,7 @@ console.log(currentPage);
 							mood: string;
 							reflections: ReflectionsType[];
 							favorite: boolean;
-              wins: Win[]
+							wins: Win[];
 						};
 					} = {};
 
@@ -117,7 +117,6 @@ console.log(currentPage);
 			currentYear = endDate.getUTCFullYear();
 		}
 	}
-
 
 	const currentMonthMoods = Object.entries(moods).filter(([date, mood]) => {
 		const dateObj = new Date(`${date}T00:00:00Z`);
@@ -176,7 +175,7 @@ console.log(currentPage);
 						return (
 							<div
 								key={date}
-								className='flex h-20 w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-blue-100 bg-boxBackground px-4  text-textPrimary hover:bg-hoverColor'
+								className='group flex h-20 w-full cursor-pointer items-center justify-between gap-4 rounded-lg border border-blue-100 bg-boxBackground px-4 py-2  text-textPrimary hover:bg-hoverColor 2xl:gap-[2.9375rem]'
 								onClick={() => {
 									handleLogClick({
 										date: dateObj,
@@ -189,34 +188,38 @@ console.log(currentPage);
 									handleDateChange(dateObj);
 								}}
 							>
-								<div className='justify-content flex flex-col items-center'>
-									<p className='text-base font-medium text-gray-600'>{day}</p>
-									<p className='text-xs text-gray-600'>{month}</p>
-								</div>
+								<div className='flex h-full w-full flex-row items-center justify-start gap-4'>
+									<div className='justify-content flex flex-col items-center gap-[0.3125rem] leading-none text-[#706F6F]'>
+										<span className='m-0 p-0 text-2xl font-medium'>{day}</span>
+										<span className='m-0 p-0 text-xs'>{month}</span>
+									</div>
 
-								<div className='h-10 border border-r border-blue-100 group-hover:border-white'></div>
-								<div className='w-20'>
-									<Image
-										src={`/moods/${mood.mood.toLowerCase()}.svg`}
-										alt='Mood'
-										width={200}
-										height={200}
-										className='w-full'
+									<div className='h-full w-[0.0625rem] bg-[#dee9f5] group-hover:bg-white'></div>
+									<div className='flex h-16 w-16 items-center justify-center rounded-lg bg-white'>
+										<Image
+											src={`/moods/${mood.mood.toLowerCase()}.svg`}
+											alt='Mood'
+											width={200}
+											height={200}
+											// className='w-full'
+										/>
+									</div>
+								</div>
+								<div className='flex h-full w-full flex-row items-center justify-start gap-4 leading-none'>
+									<div className='items-left flex w-20 flex-col justify-center gap-[0.66rem]'>
+										<span className='text-base font-medium text-black'>
+											{mood.mood.charAt(0).toUpperCase() + mood.mood.slice(1)}
+										</span>
+										<span className='text-xs text-gray-500'>
+											{moodNames[mood.mood]}
+										</span>
+									</div>
+									<CaretRight
+										className='text-black group-hover:text-blue-500'
+										size={16}
+										weight='bold'
 									/>
 								</div>
-								<div className='w-20'>
-									<p className='text-sm font-medium text-black'>
-										{mood.mood.charAt(0).toUpperCase() + mood.mood.slice(1)}
-									</p>
-									<p className='text-xs text-gray-500'>
-										{moodNames[mood.mood]}
-									</p>
-								</div>
-								<CaretRight
-									className='text-black group-hover:text-blue-500'
-									size={16}
-									weight='bold'
-								/>
 							</div>
 						);
 					})

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -166,7 +166,7 @@ const MiniCalendarView = ({
 	};
 
 	return (
-		<div className='mini-calendar flex w-64 flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
+		<div className='mini-calendar flex min-h-64 w-64 flex-col gap-4 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
 			{!isYearDropdownOpen ? (
 				<>
 					<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
@@ -194,6 +194,7 @@ const MiniCalendarView = ({
 						calendarType='gregory'
 						onChange={handleDateChange}
 						showNeighboringMonth={true}
+						showFixedNumberOfWeeks={true}
 						showNavigation={false}
 						value={tempSelectedDate}
 						tileClassName={({ date, view }) =>

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -36,6 +36,7 @@ type Props = {
 		favorite: boolean;
 		wins?: Win[];
 	}) => void;
+	logUpdate?: boolean;
 };
 
 type ValuePiece = Date | null;
@@ -50,6 +51,7 @@ const MiniCalendarView = ({
 	setValue,
 	handleDateChange,
 	handleLogClick,
+	logUpdate,
 }: Props) => {
 	const { user } = useAuth();
 	const [moods, setMoods] = useState<{ [key: string]: string }>({});
@@ -98,7 +100,11 @@ const MiniCalendarView = ({
 				}
 			});
 		}
-	}, [user]);
+	}, [user, logUpdate]);
+
+	useEffect(() => {
+		setTempSelectedDate(selectedDate);
+	}, [selectedDate]);
 
 	useEffect(() => {
 		// Function to check if clicked outside of dropdown
@@ -197,9 +203,19 @@ const MiniCalendarView = ({
 						showFixedNumberOfWeeks={true}
 						showNavigation={false}
 						value={tempSelectedDate}
-						tileClassName={({ date, view }) =>
-							isToday(date) ? 'react-calendar__tile--today' : ''
-						}
+						tileClassName={({ date, view }) => {
+							if (isToday(date)) {
+								return 'react-calendar__tile--today';
+							}
+							if (
+								date.getDate() === (selectedDate as Date).getDate() &&
+								date.getMonth() === (selectedDate as Date).getMonth() &&
+								date.getFullYear() === (selectedDate as Date).getFullYear()
+							) {
+								return 'react-calendar__tile--selected';
+							}
+							return '';
+						}}
 						onClickDay={(value: Date) => {
 							const dateKey = formatValueTypeToYYYYMMDD(value);
 							const mood = moods[dateKey];

--- a/stories/Confirmation.tsx
+++ b/stories/Confirmation.tsx
@@ -21,17 +21,15 @@ export const ConfirmationMessage = ({
 				<div className='flex w-[23rem] flex-col items-center justify-center gap-6'>
 					<Icon type='cloud-sun' size='6rem' weight='regular' />
 					<div className='flex flex-col items-center justify-center gap-2'>
-						<h4 className='text-center'>Welcome in {userDisplayName} </h4>
-						<p className='text-center'>
+						<h4 className='text-center'>Welcome in {userDisplayName}!</h4>
+						<span className='text-center text-base'>
 							You can now start logging your reflections. Let’s get started with
 							your first one!
-						</p>
+						</span>
 					</div>
 				</div>
-				<div>
-					<hr className='h-0.25 bg-lineColor'></hr>
-				</div>
-				<div className='flex w-[23rem] flex-col items-center justify-center gap-4'>
+				<div className='h-[0.0625rem] w-[27rem] bg-[#D9D9D9]'></div>
+				<div className='flex w-[23rem] flex-col items-center justify-center gap-6'>
 					<div className='flex flex-row gap-4'>
 						<Icon type='sun' size='2rem' weight='light' />
 						<p>


### PR DESCRIPTION
## Description

1. Updates the confirmation message (welcome screen) (#50 ) 
2. Adds functionality for the dropdown menu (when you click on the account at the top right) to close if you click anywhere outside of the dropdown (#51 )
3. Makes the blue dot in the big calendar a circle at all times (#51 )
4. Updates the style for the summary tiles in the summary list view to match the wireframe (#53 )
5. Additionally, changes the mini calendar to have a fixed number of weeks (6) so that the calendar occupies the same height for all the months.
6. Adds a "today" icon (a special version of the cloud icon) for today's date. It will only show up if the user has not yet logged a mood for today; if they do log a mood, it changes to the regular (chosen) cloud.
7. Updates the daily view style: does not render anything in cases of no wins; does not render the vertical blue line for the last item in the three wins array.
8. Fixes the synchronization between the mini and large calendar: before if you clicked anywhere in the big calendar, the selection would not update in the mini calendar. Now when a user clicks in the big calendar, the selection is also updated in the mini calendar.

## Related Issue

Issue #50 
Issue #51 
Issue #52 
Issue #53 

## Related Story Card

N/A

## Type of Changes

Style and function

## Acceptance Criteria

N/A

## Update Screenshots

### Before
![image](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/fc57b435-4b65-4503-8d7b-e68107679421)
![image](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/1d1ed3ff-9a93-4f38-a541-e57f33c61079)
![image](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/ff4f01a3-70c9-489e-be1f-9cc9eac9cd4e)
![Screenshot 2024-05-24 at 1 22 50 PM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/3b3b9f40-5149-4d47-a3ce-795fee4b0f3c)

### After
![Screenshot 2024-05-24 at 11 52 02 AM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/4f570a97-894b-4713-af8c-35aaf5264791)
![Screenshot 2024-05-24 at 11 53 01 AM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/87552529-3c41-40c4-861f-223f65e5c9e9)
![Screenshot 2024-05-24 at 11 53 09 AM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/214e6679-59f3-4073-9ed2-e550ecd1839c)
![Screenshot 2024-05-24 at 1 23 15 PM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/0a6ebe10-6106-48ae-8e6a-69c603cfb9bb)
![Screenshot 2024-05-24 at 1 23 30 PM](https://github.com/cherryontech/jupiter-jumpers/assets/47403135/76879444-1160-462c-afc5-bc28469d508a)

## Testing Instructions

1. Create a new account, and confirm the confirmation message is updated (exclamation mark added, horizontal line added)
2. Click the dropdown menu in the header (the user menu). Click anywhere outside the menu and ensure it closes the menu.
3. Resize the UI and ensure the blue circle in the large calendar remains circular (not oval).
4. In the summary list view, ensure each tile -- when hovered -- has the vertical line turn white and the right caret turn blue. In all states, ensure the icon has a white background with rounded corners. 
5. Toggle through all the months of the mini calendar and ensure it remains the same size.
6. View the main/big calendar, and make sure there isn't a log for "today" yet. There should be a special icon for today's date. Log a mood for today and ensure that the icon changes to the chosen mood's icon.
7. Try creating a log without any wins, and ensure that nothing shows up in that log's daily view (no "3 Wins" or anything).
9. Try creating a log with a single win, and ensure that only a single win shows up in the daily view (without a blue vertical line on the left of it).
10. Try creating a lot with at least two wins, and ensure the last item does not have a blue vertical line to the left of it.
11. Try clicking a date in the big calendar, and ensure that the selection also updates in the mini-calendar.

## Learnings (Optional)

