### PR TITLE
Adjust sizes to make month/year fit on one line

### DIFF
--- a/app/styles/miniCalendar.css
+++ b/app/styles/miniCalendar.css
@@ -303,3 +303,9 @@
 .today {
 	background-color: blue !important;
 }
+
+@media screen and (max-width: 800px) {
+	.calendar-heading {
+		font-size: 0.75rem;
+	}
+}

--- a/components/shared/miniCalendar.tsx
+++ b/components/shared/miniCalendar.tsx
@@ -175,15 +175,15 @@ const MiniCalendarView = ({
 		<div className='mini-calendar flex h-[15.3rem] max-w-[12.6rem] flex-col gap-2 rounded-xl border-[1px] border-[#DEE9F5] bg-white p-3'>
 			{!isYearDropdownOpen ? (
 				<>
-					<div className='calendar-nav flex w-full flex-row justify-between gap-2 pr-2'>
+					<div className='calendar-nav flex w-full flex-row justify-between gap-1 pr-1'>
 						<span
-							className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.625rem] rounded-lg px-1 py-1 text-base font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
+							className={`calendar-heading align-center flex w-fit cursor-pointer justify-center gap-[0.5rem] rounded-lg pl-2 text-sm font-semibold ${isYearDropdownOpen ? 'bg-[#dee9f5]' : ''}`}
 							onClick={changeYear}
 						>
 							{formatDateToMonth(tempSelectedDate as Date)}{' '}
 							{formatDateToYear(tempSelectedDate as Date)}
 						</span>
-						<div className='flex items-center justify-center gap-6'>
+						<div className='flex items-center justify-center gap-4'>
 							<button onClick={() => changeMonth(-1)}>
 								<CaretLeft weight='bold' className='text-primary' />
 							</button>


### PR DESCRIPTION
## Description

1. The month/year text in the mini calendar was wrapping to a second line for longer month names (e.g., September). I made the text smaller and adjusting paddings/gaps to make it fit on one line consistently. 

## Related Issue

N/A

## Related Story Card

N/A

## Type of Changes

Style update

## Acceptance Criteria

N/A


## Testing Instructions

1. Go through all the months of the calendar and ensure the calendar heading (Month year) always stays on one line.
2. Try re-sizing the window and ensure the calendar heading (Month Year) does not wrap to a second line at any width.

## Learnings (Optional)

_Document any things you learned or 'gotchas' you experienced._
